### PR TITLE
Release: v0.12.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Packaging repository: https://github.com/danielkza/v4l2loopback-fedora
 COPR repository: https://copr.fedorainfracloud.org/coprs/danielkza/v4l2loopback
 
 This repository contains instructions (a spec file) for packaging v4l2loopback
-for Fedora. It was tested with Fedora 22 to 24.
+for Fedora. It was tested with Fedora 30 to 31.
 
 The easiest way to build a clean and working binary package is to use Mock.
 Instructions can be found on the [Fedora Wiki on Mock](https://fedoraproject.org/wiki/Using_Mock_to_test_package_builds).

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-copr_name="$1"
+set -Eeuo pipefail
+
+copr_name="${1:-}"
 
 specs=(*.spec)
 spec="${specs[0]}"
@@ -8,7 +10,7 @@ spec="${specs[0]}"
 mkdir -p sources rpms
 spectool -g "$spec" -C sources
 
-mock_dist=$(mock --offline --shell "rpm --eval 'DIST:%{dist}'" | grep '^DIST:' | cut -d: -f2)
+mock_dist=$(mock --shell "rpm --eval 'DIST:%{dist}'" | grep '^DIST:' | cut -d: -f2)
 srpm_name=$(rpmspec -q --srpm -D "dist $mock_dist" --queryformat '%{NEVR}.src.rpm\n' "$spec" | grep 'src\.rpm$')
 
 mock --buildsrpm --sources "$PWD/sources" --spec "$PWD/$spec" --resultdir "$PWD/rpms"

--- a/v4l2loopback.spec
+++ b/v4l2loopback.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:     v4l2loopback
-Version:  0.12.3
+Version:  0.12.5
 Release:  1%{?dist}
 Summary:  Tools to create Video4Linux loopback recording devices
 Group:    System Environment/Kernel
@@ -66,6 +66,10 @@ make install-utils install-man DESTDIR="$RPM_BUILD_ROOT" PREFIX=%{_prefix} BINDI
 %{_usrsrc}/%{name}-%{version}
 
 %changelog
+* Mon May 25 2020 Chris Suszynski <ksuszyns@redhat.com> - 0.12.5-1
+- Updated upstream version to 0.12.5
+- Tested on Fedora 31 and 32
+
 * Fri Mar 27 2020 Chris Suszynski <ksuszyns@redhat.com> - 0.12.3-1
 - Updated upstream version to 0.12.3
 - Tested on Fedora 30 and 31

--- a/v4l2loopback.spec
+++ b/v4l2loopback.spec
@@ -1,8 +1,8 @@
 %global debug_package %{nil}
 
 Name:     v4l2loopback
-Version:  0.9.1
-Release:  2%{?dist}
+Version:  0.12.3
+Release:  1%{?dist}
 Summary:  Tools to create Video4Linux loopback recording devices
 Group:    System Environment/Kernel
 License:  GPLv2
@@ -37,7 +37,7 @@ This package contains the module source and DKMS configuration to build thev
 v4l2loopback kernel module.
 
 %post dkms
-%{_prefix}/lib/dkms/common.postinst %{name} %{version}
+%{_prefix}/lib${LIB_SUFFIX}/dkms/common.postinst %{name} %{version}
 
 %preun dkms
 if [ $1 -ne 1 ]; then
@@ -66,6 +66,10 @@ make install-utils install-man DESTDIR="$RPM_BUILD_ROOT" PREFIX=%{_prefix} BINDI
 %{_usrsrc}/%{name}-%{version}
 
 %changelog
+* Fri Mar 27 2020 Chris Suszynski <ksuszyns@redhat.com> - 0.12.3-1
+- Updated upstream version to 0.12.3
+- Tested on Fedora 30 and 31
+
 * Thu Jun 23 2016 Daniel Miranda <danielkza2@gmail.com> - 0.9.1-2
 - Remove unneeded build dependencies 
 - Fix DKMS trigger on package update


### PR DESCRIPTION
`v0.12.3` do not work on Fedora 32 kernel. I've updated upstream to `v0.12.5` and it works. I've tested that on Fedora 32 and 31

Supersedes #2 